### PR TITLE
fix: improve type safety and firestore utils

### DIFF
--- a/components/service-form.tsx
+++ b/components/service-form.tsx
@@ -17,7 +17,9 @@ const serviceFormSchema = z.object({
   name: z.string().min(1, "Nome do serviço é obrigatório"),
   basePrice: z.number().min(0, "Preço deve ser maior ou igual a zero"),
   description: z.string().optional(),
-  active: z.boolean().default(true),
+  // `active` is required in the schema to avoid optional/required type mismatches
+  // The default value is handled via `useForm`'s `defaultValues`
+  active: z.boolean(),
 })
 
 type ServiceFormData = z.infer<typeof serviceFormSchema>

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -39,7 +39,8 @@ export type Permission = keyof typeof PERMISSIONS
 
 export function hasPermission(userRole: UserRole | undefined, permission: Permission): boolean {
   if (!userRole) return false
-  return PERMISSIONS[permission].includes(userRole)
+  // Cast the permission list to UserRole[] so TypeScript knows the array items
+  return (PERMISSIONS[permission] as readonly UserRole[]).includes(userRole)
 }
 
 export function canAccessRoute(userRole: UserRole | undefined, route: string): boolean {


### PR DESCRIPTION
## Summary
- require explicit `active` field in service form schema
- cast Firestore user data before returning and use Timestamp consistently
- fix permission checks for stricter UserRole typing

## Testing
- `npx tsc --noEmit` *(fails: Property 'length_m_total' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689bcb6d62a4832ea4115d08f903c5e0