### PR TITLE
refactor: unify firebase init and disable ssg

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,8 @@ import { AuthProvider } from '@/lib/auth-context';
 
 export const metadata = { title: 'Oficina Insufilm Manager' };
 
+export const revalidate = 0;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,4 @@
 'use client';
-// remova estas linhas se existirem:
-// export const dynamic = 'force-dynamic';
-// export const revalidate = 0;
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,7 +1,4 @@
 'use client';
-// remova estas linhas se existirem:
-// export const dynamic = 'force-dynamic';
-// export const revalidate = 0;
 
 import { useEffect, useState } from 'react';
 import { db } from '@/lib/firebase';

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { auth } from './firebase';
+import { auth } from '@/lib/firebase';
 import {
   onAuthStateChanged,
   signInWithEmailAndPassword,
@@ -10,7 +10,7 @@ import {
   signOut,
   type User
 } from 'firebase/auth';
-import { ensureUserDoc } from './user-service';
+import { ensureUserDoc } from '@/lib/user-service';
 
 type AuthCtx = {
   user: User | null;

--- a/lib/firebase-operations.ts
+++ b/lib/firebase-operations.ts
@@ -12,7 +12,7 @@ import {
   Timestamp,
 } from "firebase/firestore"
 import { createUserWithEmailAndPassword } from "firebase/auth"
-import { auth, db } from "./firebase"
+import { auth, db } from '@/lib/firebase';
 import type {
   ScheduleBlock,
   CashEntry,

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -25,15 +25,11 @@ export const auth: Auth = (typeof window !== 'undefined')
 
 // Emuladores (dev)
 if (process.env.NEXT_PUBLIC_USE_EMULATORS === 'true') {
-  try { connectFirestoreEmulator(db, '127.0.0.1', Number(process.env.NEXT_PUBLIC_EMU_FS_PORT ?? 8080)); } catch {}
-  try { connectStorageEmulator(storage, '127.0.0.1', Number(process.env.NEXT_PUBLIC_EMU_ST_PORT ?? 9199)); } catch {}
+  try { connectFirestoreEmulator(db, '127.0.0.1', 8080); } catch {}
+  try { connectStorageEmulator(storage, '127.0.0.1', 9199); } catch {}
   if (typeof window !== 'undefined' && auth) {
     try {
-      connectAuthEmulator(
-        auth,
-        `http://127.0.0.1:${Number(process.env.NEXT_PUBLIC_EMU_AUTH_PORT ?? 9099)}`,
-        { disableWarnings: true }
-      );
+      connectAuthEmulator(auth, 'http://127.0.0.1:9099', { disableWarnings: true });
     } catch {}
   }
 }

--- a/lib/user-service.ts
+++ b/lib/user-service.ts
@@ -1,5 +1,5 @@
 // src/lib/user-service.ts
-import { db } from './firebase';
+import { db } from '@/lib/firebase';
 import {
   collection, doc, getDoc, setDoc, serverTimestamp,
   query, where, limit, getDocs


### PR DESCRIPTION
## Summary
- add global revalidate=0 to root layout to avoid static prerender
- centralize Firebase init and emulator settings
- expose auth context and firebase utilities with consistent `@/lib` imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689be5b0e254832e878ba8860eec2b75