### PR TITLE
feat: implement login page auth flows

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,37 +1,100 @@
 "use client"
 
-import type React from "react"
-
 import { useState } from "react"
 import { useRouter } from "next/navigation"
+import { z } from "zod"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { FirebaseError } from "firebase/app"
+import { sendPasswordResetEmail } from "firebase/auth"
+
 import { useAuth } from "@/lib/auth-context"
+import { auth } from "@/lib/firebase"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
 import { Loader2 } from "lucide-react"
 
+const schema = z.object({
+  email: z.string().email("Email inválido"),
+  password: z.string().min(6, "Senha deve ter no mínimo 6 caracteres"),
+})
+
+type FormData = z.infer<typeof schema>
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof FirebaseError) {
+    const map: Record<string, string> = {
+      "auth/email-already-in-use": "E-mail já cadastrado",
+      "auth/invalid-email": "E-mail inválido",
+      "auth/user-not-found": "Usuário não encontrado",
+      "auth/wrong-password": "Senha incorreta",
+      "auth/weak-password": "Senha deve ter no mínimo 6 caracteres",
+    }
+    return map[error.code] ?? "Ocorreu um erro. Tente novamente."
+  }
+  return "Ocorreu um erro. Tente novamente."
+}
+
 export default function LoginPage() {
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
   const [error, setError] = useState("")
+  const [message, setMessage] = useState("")
   const [loading, setLoading] = useState(false)
-  const { signIn } = useAuth()
+  const [isSignUp, setIsSignUp] = useState(false)
+  const { signIn, signUp } = useAuth()
   const router = useRouter()
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError("")
-    setLoading(true)
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: "", password: "" },
+  })
 
+  const onSubmit = async (data: FormData) => {
+    setError("")
+    setMessage("")
+    setLoading(true)
     try {
-      await signIn(email, password)
-      router.push("/dashboard")
-    } catch (err: any) {
-      setError("Email ou senha incorretos")
+      if (isSignUp) {
+        await signUp(data.email, data.password)
+      } else {
+        await signIn(data.email, data.password)
+      }
+      router.replace("/dashboard")
+    } catch (err) {
+      setError(getErrorMessage(err))
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleResetPassword = async () => {
+    const email = form.getValues("email")
+    setError("")
+    setMessage("")
+    if (!email) {
+      setError("Informe o email para recuperar a senha")
+      return
+    }
+    try {
+      await sendPasswordResetEmail(auth, email)
+      setMessage("Email de recuperação enviado")
+    } catch (err) {
+      setError(getErrorMessage(err))
     }
   }
 
@@ -39,48 +102,84 @@ export default function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl font-bold">Oficina Insufilm Manager</CardTitle>
-          <CardDescription>Entre com suas credenciais para acessar o sistema</CardDescription>
+          <CardTitle className="text-2xl font-bold">
+            Oficina Insufilm Manager
+          </CardTitle>
+          <CardDescription>
+            Entre com suas credenciais para acessar o sistema
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {error && (
-              <Alert variant="destructive">
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              {error && (
+                <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+              {message && (
+                <Alert>
+                  <AlertDescription>{message}</AlertDescription>
+                </Alert>
+              )}
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                disabled={loading}
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" disabled={loading} {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-            </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="password">Senha</Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                disabled={loading}
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Senha</FormLabel>
+                    <FormControl>
+                      <Input type="password" disabled={loading} {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-            </div>
 
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Entrar
-            </Button>
-          </form>
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isSignUp ? "Criar conta" : "Entrar"}
+              </Button>
+              <div className="flex flex-col space-y-2 text-center">
+                <Button
+                  type="button"
+                  variant="link"
+                  onClick={handleResetPassword}
+                  disabled={loading}
+                  className="text-sm"
+                >
+                  Esqueci a senha
+                </Button>
+                <Button
+                  type="button"
+                  variant="link"
+                  onClick={() => setIsSignUp((v) => !v)}
+                  disabled={loading}
+                  className="text-sm"
+                >
+                  {isSignUp ? "Já tenho conta" : "Criar conta"}
+                </Button>
+              </div>
+            </form>
+          </Form>
         </CardContent>
       </Card>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- refactor login page to use React Hook Form with Zod
- add sign-up mode and password reset using Firebase
- redirect authenticated users to dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

## Manual Testing
- Open `/login`
- Create account with email and password
- Log in with created account
- Use **Esqueci a senha** to trigger password reset


------
https://chatgpt.com/codex/tasks/task_e_689beaac48d8832e8f8ec5d402893146